### PR TITLE
Enables infinite precision on Money attributes based on column type

### DIFF
--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -60,8 +60,6 @@ module MoneyRails
               if MoneyRails.infer_precision?
                 column_definition = self.columns_hash[subunit_name]
                 options[:infinite_precision] = column_definition && column_definition.type == :decimal
-              else
-                options[:infinite_precision] = MoneyRails.default_infinite_precision
               end
             end
 

--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -55,9 +55,10 @@ module MoneyRails
                                    "Use :as option to explicitly specify the name or change the amount column postfix in the initializer."
             end
 
-            # Assigns infinite_precision based on the field's column type, if available
-            unless options.has_key?(:infinite_precision)
-              if MoneyRails.infer_precision?
+            # Infers precision based on field's column type when desired
+            if !options.has_key?(:infinite_precision) && MoneyRails.infer_precision?
+              # Only attempt column introspection when backing table exists
+              if self.table_exists?
                 column_definition = self.columns_hash[subunit_name]
                 options[:infinite_precision] = column_definition && column_definition.type == :decimal
               end

--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -56,7 +56,14 @@ module MoneyRails
             end
 
             # Assigns infinite_precision based on the field's column type, if available
-            options[:infinite_precision] = self.columns_hash[subunit_name].try(:type) == :decimal
+            unless options.has_key?(:infinite_precision)
+              if MoneyRails.infer_precision?
+                column_definition = self.columns_hash[subunit_name]
+                options[:infinite_precision] = column_definition && column_definition.type == :decimal
+              else
+                options[:infinite_precision] = MoneyRails.default_infinite_precision
+              end
+            end
 
             # Optional accessor to be run on an instance to detect currency
             instance_currency_name = options[:with_model_currency] ||

--- a/lib/money-rails/configuration.rb
+++ b/lib/money-rails/configuration.rb
@@ -63,6 +63,15 @@ module MoneyRails
     # Provide exchange rates
     delegate :add_rate, to: :Money
 
+    # Set infinite precision behavior
+    # If infer_precision? is set to true, will set the precision based on the column type
+    delegate :default_infinite_precision=, :default_infinite_precision, to: :Money
+    mattr_accessor :infer_precision
+    @@infer_precision = false 
+    def infer_precision?
+      @@infer_precision
+    end
+
     # Use (by default) validation of numericality for each monetized field.
     mattr_accessor :include_validations
     @@include_validations = true

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -12,7 +12,9 @@ if defined? ActiveRecord
                      sale_price_amount: 1200, delivery_fee_cents: 100,
                      restock_fee_cents: 2000,
                      reduced_price_cents: 1500, reduced_price_currency: :lvl,
-                     lambda_price_cents: 4000)
+                     lambda_price_cents: 4000,
+                     unit_cost_cents: 1234.8765
+                    )
     end
 
     describe ".monetize" do
@@ -139,6 +141,16 @@ if defined? ActiveRecord
 
       it "respects :as argument" do
         expect(product.discount_value).to eq(Money.new(150, "USD"))
+      end
+
+      it "assigns instance precision based on the column type of the attribute" do
+        expect(product.unit_cost.infinite_precision?).to eq(true)
+        expect(product.unit_cost).to eq(Money.new(1234.8765, "USD", infinite_precision: true))
+        expect(product.unit_cost.to_s).to eq("12.348765")
+
+        expect(product.price.infinite_precision?).to eq(false)
+        expect(product.price).to eq(Money.new(3000, "USD", infinite_precision: false))
+        expect(product.price.to_s).to eq("30.00")
       end
 
       it "uses numericality validation" do

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -125,6 +125,19 @@ describe "configuration" do
       MoneyRails.default_bank = old_bank
     end
 
+    it "assigns a default infinite precision" do
+      old_precision = MoneyRails.default_infinite_precision
+
+      MoneyRails.default_infinite_precision = true
+      expect(Money.default_infinite_precision).to eq(true)
+
+      MoneyRails.default_infinite_precision = old_precision
+    end
+
+    it "sets infer_precision? to false by default" do
+      expect(MoneyRails.infer_precision?).to eq(false)
+    end
+
     describe "rounding mode" do
       [BigDecimal::ROUND_UP, BigDecimal::ROUND_DOWN, BigDecimal::ROUND_HALF_UP, BigDecimal::ROUND_HALF_DOWN,
        BigDecimal::ROUND_HALF_EVEN, BigDecimal::ROUND_CEILING, BigDecimal::ROUND_FLOOR].each do |mode|

--- a/spec/dummy/app/models/product.rb
+++ b/spec/dummy/app/models/product.rb
@@ -56,4 +56,7 @@ class Product < ActiveRecord::Base
 
   # Using postfix to determine currency column (reduced_price_currency)
   monetize :reduced_price_cents, allow_nil: true
+
+  # Enable infinite_precision on this attribute
+  monetize :unit_cost_cents, allow_nil: true
 end

--- a/spec/dummy/db/migrate/20190814150759_add_precision_unit_cost_to_products.rb
+++ b/spec/dummy/db/migrate/20190814150759_add_precision_unit_cost_to_products.rb
@@ -1,0 +1,5 @@
+class AddPrecisionUnitCostToProducts < (Rails::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[4.2] : ActiveRecord::Migration)
+  def change
+    add_column :products, :unit_cost_cents, :decimal
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151026220420) do
+ActiveRecord::Schema.define(version: 20190814150759) do
 
   create_table "dummy_products", force: :cascade do |t|
     t.string   "currency"
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 20151026220420) do
     t.integer  "special_price_cents"
     t.integer  "lambda_price_cents"
     t.string   "skip_validation_price_cents"
+    t.decimal  "unit_cost_cents"
   end
 
   create_table "services", force: :cascade do |t|


### PR DESCRIPTION
Uses work on `money` gem (https://github.com/ShippingEasy/money/pull/2) and the `monetize` gem (https://github.com/ShippingEasy/monetize/pull/1) to add infinite_precision support at the instance level.  Leveraging that work these changes set the precision on the Money instance for a model attribute based on that attributes backing column type.  If it is backed by a `:decimal` column an infinite precision Money instance is created.  Otherwise a normal precision instance is created.

I considered allowing the precision to be passed as an option on `monetize`, but it seemed awkward to have the precision not match the backing column type.  If you suddenly want more / less precision, you can simply change the column.  Perhaps that was overly prescriptive though.  Similarly, the current approach does not respect the global setting for precision `Money.default_infinite_precision` and instead favors the precision implied by the backing column type.